### PR TITLE
Fix readme to avoid export the wrong method

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ```javascript
 import React, { Component } from 'react';
 import { Button, StyleSheet, ScrollView, View, Image, TouchableOpacity, Platform } from 'react-native';
-import { EAzureBlobStorageImage } from 'react-native-azure-blob-storage';
+import { EAzureBlobStorageFile } from 'react-native-azure-blob-storage';
 import CameraRoll from "@react-native-community/cameraroll";
 
  class App extends Component {
@@ -20,7 +20,7 @@ import CameraRoll from "@react-native-community/cameraroll";
     photos: []
   }
   async componentDidMount() {
-    EAzureBlobStorageImage.configure(
+    EAzureBlobStorageFile.configure(
       "Account Name", //Account Name
       "Account Key", //Account Key
       "images" //Container Name


### PR DESCRIPTION
I noticed that the readme example is using the wrong method `EAzureBlobStorageImage` which is causing an error `EAzureBlobStorageImage is undefined after importing it.` instead use EAzureBlobStorageFile  

